### PR TITLE
Port to yt dlp

### DIFF
--- a/org.gnome.Totem.Videosite.YouTubeDl.yaml
+++ b/org.gnome.Totem.Videosite.YouTubeDl.yaml
@@ -14,15 +14,14 @@ modules:
   - name: yt-dlp
     buildsystem: simple
     build-commands:
-      - pip3 install .
+      - pip3 install yt_dlp-2025.1.26-py3-none-any.whl
     sources:
-      - type: archive
-        url: https://github.com/yt-dlp/yt-dlp/releases/download/2025.01.26/yt-dlp.tar.gz
-        sha256: f9b62c5f8c3db910d693a7ac1477f44696a923ff9b0a3f9d87fefea4e10e9e04
+      - type: file
+        url: https://files.pythonhosted.org/packages/33/9b/1b28a179fb4e1c751ab2a3d39c82606a9754a0d4521d7a9b7579e08aa5f8/yt_dlp-2025.1.26-py3-none-any.whl
+        sha256: 3e76bd896b9f96601021ca192ca0fbdd195e3c3dcc28302a3a34c9bc4979da7b
         x-checker-data:
           type: anitya
           project-id: 5292
-          url-template: https://github.com/yt-dlp/yt-dlp/releases/download/$version/yt-dlp.tar.gz
     cleanup:
       - etc/
       - share/

--- a/org.gnome.Totem.Videosite.YouTubeDl.yaml
+++ b/org.gnome.Totem.Videosite.YouTubeDl.yaml
@@ -32,8 +32,8 @@ modules:
       - install -Dm755 totem-ydl-parser.py ${FLATPAK_DEST}/bin/01-totem-pl-parser-videosite-youtube-dl
     post-install:
       - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.gnome.Totem.Videosite.YouTubeDl.metainfo.xml
-      - appstream-compose --basename=org.gnome.Totem.Videosite.YouTubeDl --prefix=${FLATPAK_DEST}
-        --origin=flatpak org.gnome.Totem.Videosite.YouTubeDl
+      - appstreamcli compose --components=${FLATPAK_ID} --prefix=/ --origin=${FLATPAK_ID}
+        --result-root=${FLATPAK_DEST} --data-dir=${FLATPAK_DEST}/share/app-info/xmls ${FLATPAK_DEST}
     sources:
       - type: git
         url: https://github.com/MathieuDuponchelle/totem-ydl-parser.git

--- a/org.gnome.Totem.Videosite.YouTubeDl.yaml
+++ b/org.gnome.Totem.Videosite.YouTubeDl.yaml
@@ -11,18 +11,18 @@ build-options:
     PIP_TARGET: /app/lib/totem-pl-parser/YouTubeDl/site-packages
 
 modules:
-  - name: youtube-dl
+  - name: yt-dlp
     buildsystem: simple
     build-commands:
       - pip3 install .
     sources:
       - type: archive
-        url: https://github.com/ytdl-org/youtube-dl/releases/download/2021.12.17/youtube-dl-2021.12.17.tar.gz
-        sha256: 9f3b99c8b778455165b4525f21505e86c7ff565f3ac319e19733d810194135df
+        url: https://github.com/yt-dlp/yt-dlp/releases/download/2025.01.26/yt-dlp.tar.gz
+        sha256: f9b62c5f8c3db910d693a7ac1477f44696a923ff9b0a3f9d87fefea4e10e9e04
         x-checker-data:
           type: anitya
           project-id: 5292
-          url-template: https://github.com/ytdl-org/youtube-dl/releases/download/$version/youtube-dl-$version.tar.gz
+          url-template: https://github.com/yt-dlp/yt-dlp/releases/download/$version/yt-dlp.tar.gz
     cleanup:
       - etc/
       - share/
@@ -38,6 +38,6 @@ modules:
     sources:
       - type: git
         url: https://github.com/MathieuDuponchelle/totem-ydl-parser.git
-        commit: 14d20ac274476f00b8ad9f980941fcf3e077e900
+        commit: 5d68b98b60db11a9f9e1f3451d7a487087ab7f3e
       - type: file
         path: org.gnome.Totem.Videosite.YouTubeDl.metainfo.xml

--- a/org.gnome.Totem.Videosite.YouTubeDl.yaml
+++ b/org.gnome.Totem.Videosite.YouTubeDl.yaml
@@ -1,7 +1,7 @@
 id: org.gnome.Totem.Videosite.YouTubeDl
 runtime: org.gnome.Totem
 runtime-version: stable
-sdk: org.gnome.Sdk//42
+sdk: org.gnome.Sdk//47
 build-extension: true
 separate-locales: false
 appstream-compose: false


### PR DESCRIPTION
YouTube-Dl has not provided an official release since 2021
making this flatpak broken.
totem-ydl-parser has been updated to use yt-dlp and so we also
need to update this flatpak

I hope you don't mind

thanks !!